### PR TITLE
Fix babel loader config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,16 +46,11 @@ module.exports = {
           loader: "babel-loader",
           options: {
             presets: [
-              "@babel/preset-env",
-              {
-                targets: "> 0.25%, not dead, ie 11"
-              }
+              [ "@babel/preset-env", { targets: "> 0.25%, not dead, ie 11" } ]
             ]
           }
         }
-      }
-    ],
-    rules: [
+      },
       {
         //работа с less - css
         test: /\.less$/,


### PR DESCRIPTION
Исправления для работы бабеля

1. Ты переопределял rules, поэтому в конфиге вобще не было бабеля
2. Пресет и его настройки должны быть отдельным массивом, в документации это есть